### PR TITLE
Fix name in package.json to eliminate bones notification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "__BONES_NEEDS_A_NAME__",
+  "name": "kindercode",
   "version": "0.0.1",
-  "description": "A happy little skeleton.",
+  "description": "Teaching kids to code.",
   "main": "index.js",
   "scripts": {
     "validate": "check-node-version --node '>= 6.7.0'",


### PR DESCRIPTION
Got tired of seeing the bones warning for the name of package.json.