### PR TITLE
small red tile bug fixed and demo ready

### DIFF
--- a/app/command_pattern/konvaUtils.js
+++ b/app/command_pattern/konvaUtils.js
@@ -70,7 +70,7 @@ const collectStar = () => {
   let collectedStars = store.getState().transition.collectedStars;
   let intersection = store.getState().itemCollision.item;
   let redTile = store.getState().challenges.redTile;
-  if (intersection.type === 'yellowStars' && !intersection.collected) {
+  if (intersection.type === 'yellowStars' && !intersection.collected && !redTile.draw && !redTile.collected) {
     queueSound('collect');
     store.dispatch(collect(intersection));
     store.dispatch(incrementCollectedStars());


### PR DESCRIPTION
found a small bug where you could collect the red tile star with just a collect star. working now so you can only collect red star with collect red tile star and only collect yellow stars with collect star